### PR TITLE
Allow verifying files with untrusted self-sighed certificate.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.1)
-project(zipsign VERSION 1.0.1)
+project(zipsign VERSION 1.0.2)
 
 option(WITHOUT_TESTS   "disable unit tests"   OFF)
 

--- a/include/zipsign/verifier.hpp
+++ b/include/zipsign/verifier.hpp
@@ -24,7 +24,8 @@ public:
     bool verify(
         std::string const & filename,
         std::string const & keyring_path,
-        bool is_verbose = false);
+        bool is_verbose = false,
+        bool is_self_signed = false);
 private:
     std::vector<openssl::Certificate> signers;
 };

--- a/lib/zipsign/verifier.cc
+++ b/lib/zipsign/verifier.cc
@@ -35,7 +35,8 @@ void Verifier::addCertificate(std::string const & filename)
 bool Verifier::verify(
     std::string const & filename,
     std::string const & keyring_path,
-    bool is_verbose)
+    bool is_verbose,
+    bool is_self_signed)
 {
     bool result = false;
 
@@ -71,7 +72,7 @@ bool Verifier::verify(
 
         for (auto & cert: signers)
         {
-            if (!cert.verify(store, nullptr, cms.getCerts()))
+            if (!is_self_signed && !cert.verify(store, nullptr, cms.getCerts()))
             {
                 throw std::runtime_error("signers certificate is not valid");
             }

--- a/src/zipsign/main.cc
+++ b/src/zipsign/main.cc
@@ -71,6 +71,7 @@ namespace
         auto const & filename = args.get('f');
         auto const & cert_files = args.getList('c');
         auto is_verbose = args.contains('v');
+        auto is_self_signed = args.contains('s');
         std::string keyring_path;
         if (args.contains('k')) 
         {
@@ -86,7 +87,7 @@ namespace
             {
                 verifier.addCertificate(cert_files[1]);
             }
-            bool isValid = verifier.verify(filename, keyring_path, is_verbose);
+            bool isValid = verifier.verify(filename, keyring_path, is_verbose, is_self_signed);
 
             if (isValid)
             {
@@ -141,6 +142,7 @@ int main(int argc, char * argv[])
             "\t\tzipsign sign -f archive.zip -p key.pem -c cert.pem\n"
             "\tVerify:\n"
             "\t\tzipsign verify -f archive.zip -c cert.pem\n"
+            "\t\tzipsign verify -f archive.zip -c cert.pem --self-signed\n"
         )
     ;
 
@@ -160,6 +162,7 @@ int main(int argc, char * argv[])
         .addArg('c', "certificate", "Certificate of signer.")
         .addArg('k', "keyring", "Path of keyring file.", false)
         .addFlag('v', "verbose", "Enable additionl output")      
+        .addFlag('s', "self-signed", "Allows self signed certificates, skip cert verify")
     ;
 
     app.add("info", info)


### PR DESCRIPTION
I have a use case where my certificate is self signed (No Root CA to verify with). I can still verify it is signed with my key using the cert.

Before:
```
zipsign verify -v -f archive.zip -c cert.pem
error: signers certificate is not valid
INVALID
```

After
```
openssl verify -verbose cert.pem
CN = ******
error 20 at 0 depth lookup: unable to get local issuer certificate
error cert.pem: verification failed

zipsign verify -v -f archive.zip -c cert.pem --self-signed
VALID
```