### PR TITLE
windows-build: diable errors due to use of deprecated cpp features in…

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure
+        env:
+          CXXFLAGS: -Wno-error=cpp
         run: |
           cmake -B build
 


### PR DESCRIPTION
… depdend libraries